### PR TITLE
fix: fix bin path

### DIFF
--- a/lib/abn-validator.js
+++ b/lib/abn-validator.js
@@ -1,4 +1,3 @@
-
 "use strict";
 
 var WEIGHTS  = [ 10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19 ];
@@ -10,7 +9,7 @@ module.exports = function(abn) {
 		abn = abn.replace(/\s/g, '').replace(/-/g, '').split('');
 	}
 
-	if(abn.length != 11) {
+	if(abn.length !== 11) {
 		return false;
 	}
 
@@ -24,4 +23,4 @@ module.exports = function(abn) {
 
 	return !!div;
 
-}
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Validates Australian Business Numbers",
   "main": "lib/abn-validator.js",
   "bin": {
-    "abn-validator": "abn-validator.js"
+    "abn-validator": "bin/abn-validator.js"
   },
   "scripts": {
     "test": "mocha -R spec"


### PR DESCRIPTION
Fix bin path error when installing

Before
```bash
$ npm install abn-validator --save
npm ERR! path /Users/tuan.nguyen/dev/nodejs/batter-now/batter/node_modules/abn-validator/abn-validator.js
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/tuan.nguyen/dev/nodejs/batter-now/batter/node_modules/abn-validator/abn-validator.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/tuan.nguyen/.npm/_logs/2019-02-06T04_15_35_731Z-debug.log
```

After
```bash
$ npm i git://github.com/lightbringer1991/abn-validator.git#fix-bin-path --save
+ abn-validator@1.0.0
added 1 package from 1 contributor and audited 11250 packages in 11.5s
found 0 vulnerabilities 
```